### PR TITLE
Implement the ability to recall the user with the main job call

### DIFF
--- a/src/BlandAIBankHeist.Web/Controllers/CallController.cs
+++ b/src/BlandAIBankHeist.Web/Controllers/CallController.cs
@@ -1,15 +1,18 @@
 using System.Diagnostics;
 using BlandAIBankHeist.Web.Models;
+using BlandAIBankHeist.Web.Options;
 using BlandAIBankHeist.Web.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace BlandAIBankHeist.Web.Controllers;
 
 public sealed class CallController : Controller
 {
-    public CallController(ILogger<CallController> logger, IBlandApiService blandApiService)
+    public CallController(ILogger<CallController> logger, IOptionsMonitor<BlandApiOptions> apiOptions, IBlandApiService blandApiService)
     {
         _logger = logger;
+        _apiOptions = apiOptions;
         _blandApiService = blandApiService;
     }
 
@@ -29,7 +32,7 @@ public sealed class CallController : Controller
 
         try
         {
-            var callId = await _blandApiService.TryToQueueCallAsync(createCallDto.PhoneNumberToCall);
+            var callId = await _blandApiService.TryToQueueCallAsync(createCallDto.PhoneNumberToCall, _apiOptions.CurrentValue.BankHeistIntroductionPathwayId);
             _logger.LogInformation("User created a call with a valid phone number with call ID {CallId}.", callId);
             ViewData.Add("SuccessMessage", "Your call has been added to the queue! Please wait for the call!");
             return View();
@@ -51,5 +54,6 @@ public sealed class CallController : Controller
     }
 
     private readonly ILogger<CallController> _logger;
+    private readonly IOptionsMonitor<BlandApiOptions> _apiOptions;
     private readonly IBlandApiService _blandApiService;
 }

--- a/src/BlandAIBankHeist.Web/Endpoints/v1/ScheduleRecallEndpoint.cs
+++ b/src/BlandAIBankHeist.Web/Endpoints/v1/ScheduleRecallEndpoint.cs
@@ -1,0 +1,47 @@
+﻿using BlandAIBankHeist.Web.Options;
+using BlandAIBankHeist.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace BlandAIBankHeist.Web.Endpoints.v1;
+
+// TODO: The v1 endpoints probably should be protected by an API key or something similar.
+public static class ScheduleRecallEndpoint
+{
+    static public void MapScheduleRecallEndpoint(this WebApplication app)
+    {
+        app.MapPost("/v1/recall", ScheduleRecall);
+    }
+
+    public class ScheduleRecallAPI;
+
+    static public async Task<IResult> ScheduleRecall(ILogger<ScheduleRecallAPI> logger, IOptionsMonitor<BlandApiOptions> apiOptions,
+        IBlandApiService blandApiService, [FromBody]string callId)
+    {
+        logger.LogInformation("Schedule recall requested with call id {CallID}.", callId);
+
+        var callDetails = await blandApiService.GetCallDetailsAsync(callId);
+        if (callDetails is null)
+        {
+            return Results.BadRequest("Invalid call id provided.");
+        }
+
+        // NOTE: This is a hack as the start_time variable for the BlandAPI didn't seem to work so we have to create a task here.
+        var _ = Task.Run(async () =>
+        {
+            await Task.Delay(apiOptions.CurrentValue.RecallDelayInSeconds * 1000);
+
+            try
+            {
+                var newCallId = await blandApiService.TryToQueueCallAsync(callDetails.ToPhoneNumber, apiOptions.CurrentValue.BankHeistJobPathwayId);
+                logger.LogInformation("Successfully scheduled recall with call id {CallID}.", callId);
+            }
+            catch (InvalidOperationException ex)
+            {
+                logger.LogError(ex, "Failed to schedule recall with user with call id {CallID}.", callId);
+            }
+        });
+
+        return Results.Ok();
+    }
+}

--- a/src/BlandAIBankHeist.Web/Models/CallDetailsModel.cs
+++ b/src/BlandAIBankHeist.Web/Models/CallDetailsModel.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace BlandAIBankHeist.Web.Models;
+
+public class CallDetailsModel
+{
+    [JsonPropertyName("call_id")]
+    public required string CallId { get; init; }
+
+    [JsonPropertyName("to")]
+    public required string ToPhoneNumber { get; init; }
+}

--- a/src/BlandAIBankHeist.Web/Models/QueueCallModel.cs
+++ b/src/BlandAIBankHeist.Web/Models/QueueCallModel.cs
@@ -7,6 +7,6 @@ public sealed class QueueCallModel
     [JsonPropertyName("phone_number")]
     public required string PhoneNumber { get; init; }
 
-    [JsonPropertyName("task")]
-    public required string Task { get; init; }
+    [JsonPropertyName("pathway_id")]
+    public required string PathwayId { get; init; }
 }

--- a/src/BlandAIBankHeist.Web/Options/BlandApiOptions.cs
+++ b/src/BlandAIBankHeist.Web/Options/BlandApiOptions.cs
@@ -6,4 +6,5 @@ public sealed class BlandApiOptions
 
     public required string ApiUrl { get; init; }
     public required string ApiKey { get; init; }
+    public required string BankHeistPathwayId { get; init; }
 }

--- a/src/BlandAIBankHeist.Web/Options/BlandApiOptions.cs
+++ b/src/BlandAIBankHeist.Web/Options/BlandApiOptions.cs
@@ -7,4 +7,6 @@ public sealed class BlandApiOptions
     public required string ApiUrl { get; init; }
     public required string ApiKey { get; init; }
     public required string BankHeistIntroductionPathwayId { get; init; }
+    public required string BankHeistJobPathwayId { get; init; }
+    public required int RecallDelayInSeconds { get; init; }
 }

--- a/src/BlandAIBankHeist.Web/Options/BlandApiOptions.cs
+++ b/src/BlandAIBankHeist.Web/Options/BlandApiOptions.cs
@@ -6,5 +6,5 @@ public sealed class BlandApiOptions
 
     public required string ApiUrl { get; init; }
     public required string ApiKey { get; init; }
-    public required string BankHeistPathwayId { get; init; }
+    public required string BankHeistIntroductionPathwayId { get; init; }
 }

--- a/src/BlandAIBankHeist.Web/Program.cs
+++ b/src/BlandAIBankHeist.Web/Program.cs
@@ -1,5 +1,6 @@
 using BlandAIBankHeist.Web.Installers;
 using BlandAIBankHeist.Web.Options;
+using BlandAIBankHeist.Web.Endpoints.v1;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -29,6 +30,8 @@ app.UseAntiforgery();
 app.UseRouting();
 
 app.MapStaticAssets();
+
+app.MapScheduleRecallEndpoint();
 
 app.MapControllerRoute(
     name: "default",

--- a/src/BlandAIBankHeist.Web/Services/BlandApiService.cs
+++ b/src/BlandAIBankHeist.Web/Services/BlandApiService.cs
@@ -45,6 +45,33 @@ public class BlandApiService : IBlandApiService
         }
     }
 
+    public async Task<CallDetailsModel?> GetCallDetailsAsync(string callId)
+    {
+        var client = CreateAuthorizedHttpClientForBlandApi();
+
+        var response = await client.GetAsync($"/v1/calls/{callId}");
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed to get call details from BlandAPI with call id {CallID}.", callId);
+            return null;
+        }
+
+        try
+        {
+            var callDetails = await response.Content.ReadFromJsonAsync<CallDetailsModel>();
+
+            _logger.LogInformation("Successfully got call details from BlandAPI with call id {CallID}.", callId);
+            return callDetails;
+        }
+        catch (JsonException)
+        {
+            _logger.LogError("Successful status code from BlandAI API, however, an invalid response of {Response} was returned.",
+                await response.Content.ReadAsStringAsync());
+
+            return null;
+        }
+    }
+
     private HttpClient CreateAuthorizedHttpClientForBlandApi()
     {
         var client = _httpClientFactory.CreateClient();

--- a/src/BlandAIBankHeist.Web/Services/BlandApiService.cs
+++ b/src/BlandAIBankHeist.Web/Services/BlandApiService.cs
@@ -19,7 +19,8 @@ public class BlandApiService : IBlandApiService
     {
         var client = CreateAuthorizedHttpClientForBlandApi();
 
-        var response = await client.PostAsJsonAsync("/v1/calls", new QueueCallModel { PhoneNumber = phoneNumber, Task = "Greet User like a Bank Teller." });
+        var response = await client.PostAsJsonAsync("/v1/calls", new QueueCallModel { PhoneNumber = phoneNumber,
+            PathwayId = _apiOptions.CurrentValue.BankHeistPathwayId });
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogError("Failed to queue a call with the BlandAI API with the code {Code} and reponse {Response}.",

--- a/src/BlandAIBankHeist.Web/Services/BlandApiService.cs
+++ b/src/BlandAIBankHeist.Web/Services/BlandApiService.cs
@@ -15,12 +15,11 @@ public class BlandApiService : IBlandApiService
         _httpClientFactory = httpClientFactory;
     }
 
-    public async Task<string> TryToQueueCallAsync(string phoneNumber)
+    public async Task<string> TryToQueueCallAsync(string phoneNumber, string pathwayId)
     {
         var client = CreateAuthorizedHttpClientForBlandApi();
 
-        var response = await client.PostAsJsonAsync("/v1/calls", new QueueCallModel { PhoneNumber = phoneNumber,
-            PathwayId = _apiOptions.CurrentValue.BankHeistPathwayId });
+        var response = await client.PostAsJsonAsync("/v1/calls", new QueueCallModel { PhoneNumber = phoneNumber, PathwayId = pathwayId });
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogError("Failed to queue a call with the BlandAI API with the code {Code} and reponse {Response}.",
@@ -33,7 +32,8 @@ public class BlandApiService : IBlandApiService
         {
             var successfulQueueCallResponse = await response.Content.ReadFromJsonAsync<SuccessfulQueueCallResponse>();
 
-            _logger.LogInformation("Call was successfully queued with call id of {CallId}.", successfulQueueCallResponse!.CallId);
+            _logger.LogInformation("Call was successfully queued with call id of {CallId} and pathway id {PathwayId}.",
+                successfulQueueCallResponse!.CallId, pathwayId);
             return successfulQueueCallResponse.CallId;
         }
         catch (JsonException)

--- a/src/BlandAIBankHeist.Web/Services/IBlandApiService.cs
+++ b/src/BlandAIBankHeist.Web/Services/IBlandApiService.cs
@@ -4,6 +4,6 @@ namespace BlandAIBankHeist.Web.Services;
 
 public interface IBlandApiService
 {
-    public Task<string> TryToQueueCallAsync(string phoneNumber);
+    public Task<string> TryToQueueCallAsync(string phoneNumber, string pathwayId);
     public Task<CallDetailsModel?> GetCallDetailsAsync(string callId);
 }

--- a/src/BlandAIBankHeist.Web/Services/IBlandApiService.cs
+++ b/src/BlandAIBankHeist.Web/Services/IBlandApiService.cs
@@ -1,6 +1,9 @@
-﻿namespace BlandAIBankHeist.Web.Services;
+﻿using BlandAIBankHeist.Web.Models;
+
+namespace BlandAIBankHeist.Web.Services;
 
 public interface IBlandApiService
 {
     public Task<string> TryToQueueCallAsync(string phoneNumber);
+    public Task<CallDetailsModel?> GetCallDetailsAsync(string callId);
 }

--- a/src/BlandAIBankHeist.Web/appsettings.Development.json
+++ b/src/BlandAIBankHeist.Web/appsettings.Development.json
@@ -2,7 +2,10 @@
   "Serilog": {
     "Using": [],
     "MinimumLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning"
+      }
     },
     "WriteTo": [
       {

--- a/src/BlandAIBankHeist.Web/appsettings.json
+++ b/src/BlandAIBankHeist.Web/appsettings.json
@@ -12,7 +12,9 @@
   },
   "BlandApi": {
     "ApiUrl": "https://us.api.bland.ai/",
-    "BankHeistIntroductionPathwayId": "da8fa7a6-5319-4540-834d-477aaff2d2dc"
+    "BankHeistIntroductionPathwayId": "da8fa7a6-5319-4540-834d-477aaff2d2dc",
+    "BankHeistJobPathwayId": "783e7684-e289-4bf9-ae49-c1d8bcbf8d08",
+    "RecallDelayInSeconds": 20
   },
   "AllowedHosts": "*"
 }

--- a/src/BlandAIBankHeist.Web/appsettings.json
+++ b/src/BlandAIBankHeist.Web/appsettings.json
@@ -12,7 +12,7 @@
   },
   "BlandApi": {
     "ApiUrl": "https://us.api.bland.ai/",
-    "BankHeistPathwayId": "2aa47a74-f894-4ee6-aeba-d412fcfc7dff"
+    "BankHeistIntroductionPathwayId": "da8fa7a6-5319-4540-834d-477aaff2d2dc"
   },
   "AllowedHosts": "*"
 }

--- a/src/BlandAIBankHeist.Web/appsettings.json
+++ b/src/BlandAIBankHeist.Web/appsettings.json
@@ -11,7 +11,8 @@
     ]
   },
   "BlandApi": {
-    "ApiUrl": "https://us.api.bland.ai/"
+    "ApiUrl": "https://us.api.bland.ai/",
+    "BankHeistPathwayId": "2aa47a74-f894-4ee6-aeba-d412fcfc7dff"
   },
   "AllowedHosts": "*"
 }

--- a/test/BlandAIBankHeist.Web.UnitTests/BlandApiServiceTests.cs
+++ b/test/BlandAIBankHeist.Web.UnitTests/BlandApiServiceTests.cs
@@ -72,7 +72,7 @@ public sealed class BlandApiServiceTests
     {
         // Arrange
         _httpMessageHandler.Expect(_fakeCallUrl)
-            .WithJsonContent(new QueueCallModel { PhoneNumber = _expectedPhoneNumber, Task = "Greet User like a Bank Teller." })
+            .WithJsonContent(new QueueCallModel { PhoneNumber = _expectedPhoneNumber, PathwayId = _fakePathwayId })
             .Respond("application/json", $"{{\"status\": \"success\", \"call_id\": \"\"}}");
 
         // Act
@@ -104,8 +104,9 @@ public sealed class BlandApiServiceTests
     private readonly MockHttpMessageHandler _httpMessageHandler = new();
 
     private const string _fakeApiUrl = "https://www.FakeApiUrl.com";
+    private const string _fakePathwayId = nameof(_fakePathwayId);
     private const string _expectedPhoneNumber = nameof(_expectedPhoneNumber);
 
-    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = _fakeApiUrl, ApiKey = "FakeApiKey" };
+    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = _fakeApiUrl, ApiKey = "FakeApiKey", BankHeistPathwayId = _fakePathwayId };
     private readonly string _fakeCallUrl = $"{_fakeApiUrl}/v1/calls";
 }

--- a/test/BlandAIBankHeist.Web.UnitTests/BlandApiServiceTests.cs
+++ b/test/BlandAIBankHeist.Web.UnitTests/BlandApiServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class BlandApiServiceTests
 
         // Act
         // Assert
-        await _sut.Invoking(x => x.TryToQueueCallAsync(_expectedPhoneNumber))
+        await _sut.Invoking(x => x.TryToQueueCallAsync(_expectedPhoneNumber, _fakePathwayId))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Failed to queue call with the BlandAI API.");
     }
@@ -46,7 +46,7 @@ public sealed class BlandApiServiceTests
 
         // Act
         // Assert
-        await _sut.Invoking(x => x.TryToQueueCallAsync(_expectedPhoneNumber))
+        await _sut.Invoking(x => x.TryToQueueCallAsync(_expectedPhoneNumber, _fakePathwayId))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Failed to parse response from BlandAI API.");
     }
@@ -61,14 +61,14 @@ public sealed class BlandApiServiceTests
             .Respond("application/json", $"{{\"status\": \"success\", \"call_id\": \"{expectedCallId}\"}}");
 
         // Act
-        var callId = await _sut.TryToQueueCallAsync(_expectedPhoneNumber);
+        var callId = await _sut.TryToQueueCallAsync(_expectedPhoneNumber, _fakePathwayId);
 
         // Assert
         callId.Should().Be(expectedCallId);
     }
 
     [Fact]
-    public async Task TryToQueueCallAsync_UsesExpectedPhoneNumber_WhenUsingBlandAPI()
+    public async Task TryToQueueCallAsync_UsesExpectedPhoneNumberAndPathwayId_WhenUsingBlandAPI()
     {
         // Arrange
         _httpMessageHandler.Expect(_fakeCallUrl)
@@ -76,7 +76,7 @@ public sealed class BlandApiServiceTests
             .Respond("application/json", $"{{\"status\": \"success\", \"call_id\": \"\"}}");
 
         // Act
-        await _sut.TryToQueueCallAsync(_expectedPhoneNumber);
+        await _sut.TryToQueueCallAsync(_expectedPhoneNumber, _fakePathwayId);
 
         // Assert
         _httpMessageHandler.VerifyNoOutstandingExpectation();
@@ -91,7 +91,7 @@ public sealed class BlandApiServiceTests
             .Respond("application/json", $"{{\"status\": \"success\", \"call_id\": \"\"}}");
 
         // Act
-        await _sut.TryToQueueCallAsync(_expectedPhoneNumber);
+        await _sut.TryToQueueCallAsync(_expectedPhoneNumber, _fakePathwayId);
 
         // Assert
         _httpMessageHandler.VerifyNoOutstandingExpectation();
@@ -185,7 +185,7 @@ public sealed class BlandApiServiceTests
     private const string _fakeCallId = nameof(_fakeCallId);
     private const string _expectedPhoneNumber = nameof(_expectedPhoneNumber);
 
-    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = _fakeApiUrl, ApiKey = "FakeApiKey", BankHeistPathwayId = _fakePathwayId };
+    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = _fakeApiUrl, ApiKey = "FakeApiKey", BankHeistIntroductionPathwayId = _fakePathwayId };
     private readonly string _fakeCallUrl = $"{_fakeApiUrl}/v1/calls";
     private readonly string _fakeCallDetailsUrl = $"{_fakeApiUrl}/v1/calls/{_fakeCallId}";
 }

--- a/test/BlandAIBankHeist.Web.UnitTests/BlandApiServiceTests.cs
+++ b/test/BlandAIBankHeist.Web.UnitTests/BlandApiServiceTests.cs
@@ -185,7 +185,8 @@ public sealed class BlandApiServiceTests
     private const string _fakeCallId = nameof(_fakeCallId);
     private const string _expectedPhoneNumber = nameof(_expectedPhoneNumber);
 
-    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = _fakeApiUrl, ApiKey = "FakeApiKey", BankHeistIntroductionPathwayId = _fakePathwayId };
+    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = _fakeApiUrl, ApiKey = "FakeApiKey", BankHeistIntroductionPathwayId = _fakePathwayId,
+        BankHeistJobPathwayId = "", RecallDelayInSeconds = 0 };
     private readonly string _fakeCallUrl = $"{_fakeApiUrl}/v1/calls";
     private readonly string _fakeCallDetailsUrl = $"{_fakeApiUrl}/v1/calls/{_fakeCallId}";
 }

--- a/test/BlandAIBankHeist.Web.UnitTests/CallControllerTests.cs
+++ b/test/BlandAIBankHeist.Web.UnitTests/CallControllerTests.cs
@@ -1,9 +1,11 @@
 ﻿using BlandAIBankHeist.Web.Controllers;
 using BlandAIBankHeist.Web.Models;
+using BlandAIBankHeist.Web.Options;
 using BlandAIBankHeist.Web.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
@@ -13,7 +15,10 @@ public sealed class CallControllerTests
 {
     public CallControllerTests()
     {
-        _sut = new(NullLogger<CallController>.Instance, _blandApiService);
+        _sut = new(NullLogger<CallController>.Instance, _apiOptionsMonitor, _blandApiService);
+
+        _apiOptionsMonitor.CurrentValue
+            .Returns(_fakeBlandApiOptions);
     }
 
     [Fact]
@@ -52,7 +57,7 @@ public sealed class CallControllerTests
     }
 
     [Fact]
-    public async Task IndexPost_WithValidPhoneNumber_TriesToQueueCall_WithExpectedPhoneNumber()
+    public async Task IndexPost_WithValidPhoneNumber_TriesToQueueCall_WithExpectedPhoneNumberAndPathwayId()
     {
         // Arrange
         const string expectedPhoneNumber = nameof(expectedPhoneNumber);
@@ -64,7 +69,7 @@ public sealed class CallControllerTests
         // Assert
         await _blandApiService
             .Received(1)
-            .TryToQueueCallAsync(expectedPhoneNumber);
+            .TryToQueueCallAsync(expectedPhoneNumber, _fakePathwayId);
     }
 
 
@@ -74,7 +79,7 @@ public sealed class CallControllerTests
         // Arrange
         var dummyDto = new CreateCallDTO("valid");
 
-        _blandApiService.TryToQueueCallAsync(Arg.Any<string>())
+        _blandApiService.TryToQueueCallAsync(Arg.Any<string>(), Arg.Any<string>())
             .Throws<InvalidOperationException>();
 
         // Act
@@ -89,5 +94,9 @@ public sealed class CallControllerTests
 
     private readonly CallController _sut;
 
+    private const string _fakePathwayId = nameof(_fakePathwayId);
+
+    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = "", ApiKey = "", BankHeistIntroductionPathwayId = _fakePathwayId };
+    private readonly IOptionsMonitor<BlandApiOptions> _apiOptionsMonitor = Substitute.For<IOptionsMonitor<BlandApiOptions>>();
     private readonly IBlandApiService _blandApiService = Substitute.For<IBlandApiService>();
 }

--- a/test/BlandAIBankHeist.Web.UnitTests/CallControllerTests.cs
+++ b/test/BlandAIBankHeist.Web.UnitTests/CallControllerTests.cs
@@ -96,7 +96,8 @@ public sealed class CallControllerTests
 
     private const string _fakePathwayId = nameof(_fakePathwayId);
 
-    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = "", ApiKey = "", BankHeistIntroductionPathwayId = _fakePathwayId };
+    private readonly BlandApiOptions _fakeBlandApiOptions = new() { ApiUrl = "", ApiKey = "", BankHeistIntroductionPathwayId = _fakePathwayId,
+        BankHeistJobPathwayId = "", RecallDelayInSeconds = 0 };
     private readonly IOptionsMonitor<BlandApiOptions> _apiOptionsMonitor = Substitute.For<IOptionsMonitor<BlandApiOptions>>();
     private readonly IBlandApiService _blandApiService = Substitute.For<IBlandApiService>();
 }


### PR DESCRIPTION
We now have an endpoint for recalling a user with the main job call to continue the game.
This endpoint is located at /v1/recall and uses a webhook from BlandAI when the introduction call ends.